### PR TITLE
Fix: Regtest config

### DIFF
--- a/docker/regtest.conf
+++ b/docker/regtest.conf
@@ -3,24 +3,25 @@ blockchain.config.name = "regtest"
 # database.dir = /var/lib/rsk/database/regtest
 
 rpc {
-providers : {
-    web: {
-        cors: "localhost",
-        http: {
-            enabled: true,
-            bind_address = "0.0.0.0",
-            hosts = ["localhost"]
-            port: 4444,
-            }
-        ws: {
-            enabled: true,
-            bind_address: "0.0.0.0",
-            port: 4445,
-            }
-        }
+    providers : {
+        web: {
+            cors: "localhost",
+            http: {
+                enabled: true,
+                bind_address: "0.0.0.0",
+                hosts: ["localhost"],
+                port: 4444,
+            },
+            ws: {
+                enabled: true,
+                bind_address: "0.0.0.0",
+                hosts: ["localhost"],
+                port: 4445,
+            },
+        },
     }
 
-    modules = [
+    modules: [
         {
             name: "eth",
             version: "1.0",

--- a/docker/regtest.conf
+++ b/docker/regtest.conf
@@ -10,17 +10,16 @@ rpc {
                 enabled: true,
                 bind_address: "0.0.0.0",
                 hosts: ["localhost"],
-                port: 4444,
+                port: 4444
             },
             ws: {
                 enabled: true,
                 bind_address: "0.0.0.0",
                 hosts: ["localhost"],
-                port: 4445,
-            },
-        },
-    }
-
+                port: 4445
+            }
+        }
+    },
     modules: [
         {
             name: "eth",

--- a/docker/websocket-test.js
+++ b/docker/websocket-test.js
@@ -1,0 +1,45 @@
+var WebSocketClient = require('websocket').client;
+
+var client = new WebSocketClient();
+
+function onWsConnectionFailed(error) {
+  console.log('Websocket connection error: ' + error.toString());
+}
+
+function onWsConnect(connection) {
+  console.log('Websocket connected');
+  connection.on('error', function(error) {
+      console.log("Websocket error: " + error.toString());
+  });
+  connection.on('close', function() {
+      console.log('Websocket closed');
+  });
+  connection.on('message', function(message) {
+      if (message.type === 'utf8') {
+          console.log("Websocket received: " + message.utf8Data);
+      }
+  });
+  
+  function makeRequest() {
+      if (connection.connected) {
+          const data = {
+            jsonrpc: '2.0',
+            method: 'eth_blockNumber',
+            params: [],
+            id: 1,
+          };
+          // const data = {
+          //   jsonrpc: '2.0',
+          //   method: 'eth_getBlockByNumber',
+          //   params: ['0x0', true], 
+          //   id: 1,
+          // };
+          connection.sendUTF(JSON.stringify(data));
+      }
+  }
+  makeRequest();
+}
+
+client.on('connectFailed', onWsConnectionFailed);
+client.on('connect', onWsConnect);
+client.connect('ws://localhost:4445/websocket');


### PR DESCRIPTION
## What

- Cleaned up the config file used by regtest
- Added a util file to quickly determine if the RSKj regtest node has websockets exposed properly

## Why

- The forked version of ganache was unable to connect to the RSKj regtest running in docker
